### PR TITLE
Fix texture path mismatches for Minecraft 26.1.x

### DIFF
--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_all_black.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_all_black.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat",
   "textures": {
-    "0": "entity/cat/all_black"
+    "0": "entity/cat/cat_all_black"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_black.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_black.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat",
   "textures": {
-    "0": "entity/cat/black"
+    "0": "entity/cat/cat_black"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_british_shorthair.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_british_shorthair.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat",
   "textures": {
-    "0": "entity/cat/british_shorthair"
+    "0": "entity/cat/cat_british_shorthair"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_calico.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_calico.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat",
   "textures": {
-    "0": "entity/cat/calico"
+    "0": "entity/cat/cat_calico"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_jellie.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_jellie.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat",
   "textures": {
-    "0": "entity/cat/jellie"
+    "0": "entity/cat/cat_jellie"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_persian.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_persian.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat",
   "textures": {
-    "0": "entity/cat/persian"
+    "0": "entity/cat/cat_persian"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_ragdoll.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_ragdoll.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat",
   "textures": {
-    "0": "entity/cat/ragdoll"
+    "0": "entity/cat/cat_ragdoll"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_red.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_red.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat",
   "textures": {
-    "0": "entity/cat/red"
+    "0": "entity/cat/cat_red"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_siamese.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_siamese.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat",
   "textures": {
-    "0": "entity/cat/siamese"
+    "0": "entity/cat/cat_siamese"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_tabby.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_tabby.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat",
   "textures": {
-    "0": "entity/cat/tabby"
+    "0": "entity/cat/cat_tabby"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_white.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_adult_white.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat",
   "textures": {
-    "0": "entity/cat/white"
+    "0": "entity/cat/cat_white"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_all_black.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_all_black.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat_baby",
   "textures": {
-    "0": "entity/cat/all_black"
+    "0": "entity/cat/cat_all_black"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_black.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_black.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat_baby",
   "textures": {
-    "0": "entity/cat/black"
+    "0": "entity/cat/cat_black"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_british_shorthair.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_british_shorthair.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat_baby",
   "textures": {
-    "0": "entity/cat/british_shorthair"
+    "0": "entity/cat/cat_british_shorthair"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_calico.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_calico.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat_baby",
   "textures": {
-    "0": "entity/cat/calico"
+    "0": "entity/cat/cat_calico"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_jellie.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_jellie.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat_baby",
   "textures": {
-    "0": "entity/cat/jellie"
+    "0": "entity/cat/cat_jellie"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_persian.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_persian.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat_baby",
   "textures": {
-    "0": "entity/cat/persian"
+    "0": "entity/cat/cat_persian"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_ragdoll.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_ragdoll.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat_baby",
   "textures": {
-    "0": "entity/cat/ragdoll"
+    "0": "entity/cat/cat_ragdoll"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_red.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_red.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat_baby",
   "textures": {
-    "0": "entity/cat/red"
+    "0": "entity/cat/cat_red"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_siamese.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_siamese.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat_baby",
   "textures": {
-    "0": "entity/cat/siamese"
+    "0": "entity/cat/cat_siamese"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_tabby.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_tabby.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat_baby",
   "textures": {
-    "0": "entity/cat/tabby"
+    "0": "entity/cat/cat_tabby"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_white.json
+++ b/src/main/resources/assets/minecraft/models/entity/cat/color/cat_baby_white.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/cat/cat_baby",
   "textures": {
-    "0": "entity/cat/white"
+    "0": "entity/cat/cat_white"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/chicken/adult.json
+++ b/src/main/resources/assets/minecraft/models/entity/chicken/adult.json
@@ -2,7 +2,7 @@
   "credit": "Model by Miraculixx",
   "texture_size": [64, 32],
   "textures": {
-    "0": "entity/chicken/temperate_chicken"
+    "0": "entity/chicken/chicken_temperate"
   },
   "elements": [
     {

--- a/src/main/resources/assets/minecraft/models/entity/chicken/adult_cold.json
+++ b/src/main/resources/assets/minecraft/models/entity/chicken/adult_cold.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/chicken/adult",
   "textures": {
-    "0": "entity/chicken/cold_chicken"
+    "0": "entity/chicken/chicken_cold"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/chicken/adult_temperate.json
+++ b/src/main/resources/assets/minecraft/models/entity/chicken/adult_temperate.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/chicken/adult",
   "textures": {
-    "0": "entity/chicken/temperate_chicken"
+    "0": "entity/chicken/chicken_temperate"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/chicken/adult_warm.json
+++ b/src/main/resources/assets/minecraft/models/entity/chicken/adult_warm.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/chicken/adult",
   "textures": {
-    "0": "entity/chicken/warm_chicken"
+    "0": "entity/chicken/chicken_warm"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/chicken/baby.json
+++ b/src/main/resources/assets/minecraft/models/entity/chicken/baby.json
@@ -2,7 +2,7 @@
   "credit": "Model by Miraculixx",
   "texture_size": [64, 32],
   "textures": {
-    "0": "entity/chicken/temperate_chicken"
+    "0": "entity/chicken/chicken_temperate"
   },
   "elements": [
     {

--- a/src/main/resources/assets/minecraft/models/entity/chicken/baby_cold.json
+++ b/src/main/resources/assets/minecraft/models/entity/chicken/baby_cold.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/chicken/baby",
   "textures": {
-    "0": "entity/chicken/cold_chicken"
+    "0": "entity/chicken/chicken_cold"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/chicken/baby_temperate.json
+++ b/src/main/resources/assets/minecraft/models/entity/chicken/baby_temperate.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/chicken/baby",
   "textures": {
-    "0": "entity/chicken/temperate_chicken"
+    "0": "entity/chicken/chicken_temperate"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/chicken/baby_warm.json
+++ b/src/main/resources/assets/minecraft/models/entity/chicken/baby_warm.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/chicken/baby",
   "textures": {
-    "0": "entity/chicken/warm_chicken"
+    "0": "entity/chicken/chicken_warm"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cow/adult_cold.json
+++ b/src/main/resources/assets/minecraft/models/entity/cow/adult_cold.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/cow/adult",
   "textures": {
-    "0": "entity/cow/cold_cow"
+    "0": "entity/cow/cow_cold"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cow/adult_temperate.json
+++ b/src/main/resources/assets/minecraft/models/entity/cow/adult_temperate.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/cow/adult",
   "textures": {
-    "0": "entity/cow/temperate_cow"
+    "0": "entity/cow/cow_temperate"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cow/adult_warm.json
+++ b/src/main/resources/assets/minecraft/models/entity/cow/adult_warm.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/cow/adult",
   "textures": {
-    "0": "entity/cow/warm_cow"
+    "0": "entity/cow/cow_warm"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cow/baby_cold.json
+++ b/src/main/resources/assets/minecraft/models/entity/cow/baby_cold.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/cow/baby",
   "textures": {
-    "0": "entity/cow/cold_cow"
+    "0": "entity/cow/cow_cold"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cow/baby_temperate.json
+++ b/src/main/resources/assets/minecraft/models/entity/cow/baby_temperate.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/cow/baby",
   "textures": {
-    "0": "entity/cow/temperate_cow"
+    "0": "entity/cow/cow_temperate"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/cow/baby_warm.json
+++ b/src/main/resources/assets/minecraft/models/entity/cow/baby_warm.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/cow/baby",
   "textures": {
-    "0": "entity/cow/warm_cow"
+    "0": "entity/cow/cow_warm"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/dolphin/adult.json
+++ b/src/main/resources/assets/minecraft/models/entity/dolphin/adult.json
@@ -3,7 +3,7 @@
 	"credit": "Made by Miraculixx",
 	"texture_size": [64, 64],
 	"textures": {
-		"0": "entity/dolphin"
+		"0": "entity/dolphin/dolphin"
 	},
 	"elements": [
 		{

--- a/src/main/resources/assets/minecraft/models/entity/dolphin/baby.json
+++ b/src/main/resources/assets/minecraft/models/entity/dolphin/baby.json
@@ -3,7 +3,7 @@
 	"credit": "Made by Miraculixx",
 	"texture_size": [64, 64],
 	"textures": {
-		"0": "entity/dolphin"
+		"0": "entity/dolphin/dolphin"
 	},
 	"elements": [
 		{

--- a/src/main/resources/assets/minecraft/models/entity/fox/adult_snow.json
+++ b/src/main/resources/assets/minecraft/models/entity/fox/adult_snow.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/fox/adult",
   "textures": {
-    "0": "entity/fox/snow_fox"
+    "0": "entity/fox/fox_snow"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/fox/baby_snow.json
+++ b/src/main/resources/assets/minecraft/models/entity/fox/baby_snow.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/fox/baby",
   "textures": {
-    "0": "entity/fox/snow_fox"
+    "0": "entity/fox/fox_snow"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/guardian/guardian.json
+++ b/src/main/resources/assets/minecraft/models/entity/guardian/guardian.json
@@ -3,7 +3,7 @@
 	"credit": "Made by Miraculixx",
 	"texture_size": [64, 64],
 	"textures": {
-		"0": "entity/guardian"
+		"0": "entity/guardian/guardian"
 	},
 	"elements": [
 		{

--- a/src/main/resources/assets/minecraft/models/entity/llama/color/llama_adult_brown.json
+++ b/src/main/resources/assets/minecraft/models/entity/llama/color/llama_adult_brown.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/llama/llama",
   "textures": {
-    "0": "entity/llama/brown"
+    "0": "entity/llama/llama_brown"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/llama/color/llama_adult_creamy.json
+++ b/src/main/resources/assets/minecraft/models/entity/llama/color/llama_adult_creamy.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/llama/llama",
   "textures": {
-    "0": "entity/llama/creamy"
+    "0": "entity/llama/llama_creamy"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/llama/color/llama_adult_gray.json
+++ b/src/main/resources/assets/minecraft/models/entity/llama/color/llama_adult_gray.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/llama/llama",
   "textures": {
-    "0": "entity/llama/gray"
+    "0": "entity/llama/llama_gray"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/llama/color/llama_adult_white.json
+++ b/src/main/resources/assets/minecraft/models/entity/llama/color/llama_adult_white.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/llama/llama",
   "textures": {
-    "0": "entity/llama/white"
+    "0": "entity/llama/llama_white"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/llama/color/llama_baby_brown.json
+++ b/src/main/resources/assets/minecraft/models/entity/llama/color/llama_baby_brown.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/llama/llama_baby",
   "textures": {
-    "0": "entity/llama/brown"
+    "0": "entity/llama/llama_brown"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/llama/color/llama_baby_creamy.json
+++ b/src/main/resources/assets/minecraft/models/entity/llama/color/llama_baby_creamy.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/llama/llama_baby",
   "textures": {
-    "0": "entity/llama/creamy"
+    "0": "entity/llama/llama_creamy"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/llama/color/llama_baby_gray.json
+++ b/src/main/resources/assets/minecraft/models/entity/llama/color/llama_baby_gray.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/llama/llama_baby",
   "textures": {
-    "0": "entity/llama/gray"
+    "0": "entity/llama/llama_gray"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/llama/color/llama_baby_white.json
+++ b/src/main/resources/assets/minecraft/models/entity/llama/color/llama_baby_white.json
@@ -1,6 +1,6 @@
 {
   "parent": "entity/llama/llama_baby",
   "textures": {
-    "0": "entity/llama/white"
+    "0": "entity/llama/llama_white"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/pig/adult_cold.json
+++ b/src/main/resources/assets/minecraft/models/entity/pig/adult_cold.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/pig/adult",
   "textures": {
-    "0": "entity/pig/cold_pig"
+    "0": "entity/pig/pig_cold"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/pig/adult_temperate.json
+++ b/src/main/resources/assets/minecraft/models/entity/pig/adult_temperate.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/pig/adult",
   "textures": {
-    "0": "entity/pig/temperate_pig"
+    "0": "entity/pig/pig_temperate"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/pig/adult_warm.json
+++ b/src/main/resources/assets/minecraft/models/entity/pig/adult_warm.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/pig/adult",
   "textures": {
-    "0": "entity/pig/warm_pig"
+    "0": "entity/pig/pig_warm"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/pig/baby_cold.json
+++ b/src/main/resources/assets/minecraft/models/entity/pig/baby_cold.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/pig/baby",
   "textures": {
-    "0": "entity/pig/cold_pig"
+    "0": "entity/pig/pig_cold"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/pig/baby_temperate.json
+++ b/src/main/resources/assets/minecraft/models/entity/pig/baby_temperate.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/pig/baby",
   "textures": {
-    "0": "entity/pig/temperate_pig"
+    "0": "entity/pig/pig_temperate"
   }
 }

--- a/src/main/resources/assets/minecraft/models/entity/pig/baby_warm.json
+++ b/src/main/resources/assets/minecraft/models/entity/pig/baby_warm.json
@@ -1,6 +1,6 @@
 {
   "parent": "minecraft:entity/pig/baby",
   "textures": {
-    "0": "entity/pig/warm_pig"
+    "0": "entity/pig/pig_warm"
   }
 }


### PR DESCRIPTION
## Summary
- Fixes texture paths in 55 model JSON files that broke with Minecraft 26.1.x due to Mojang renaming biome-variant entity textures
- Affected entities: cow, pig, chicken (biome variants), cat (all color variants), llama (all color variants), fox (snow variant), dolphin, guardian

## Changes
Mojang reversed the naming convention for biome-variant textures (e.g. `cold_cow` → `cow_cold`) and added type prefixes to cat and llama textures. All model JSON files have been updated to match the current client jar.

## Test plan
- [x] Biome-variant cows, pigs, and chickens render with correct textures
- [ ] All cat color variants render correctly
- [ ] All llama color variants render correctly
- [ ] Snow fox renders correctly
- [ ] Dolphin and guardian render correctly

Closes #3